### PR TITLE
feat: Windows 경로 지원 및 version 명령 추가

### DIFF
--- a/CLAUDE.local.md
+++ b/CLAUDE.local.md
@@ -1,0 +1,3 @@
+- Windows에서 macOS/Linux 경로인 c:/usr/local/bin/를 사용 중 문제 발견. 윈도우용 적절한 설치 경로 필요
+  - 윈도우에 맞는 경로 예시: C:\Program Files\PyHubInstaller 또는 %LOCALAPPDATA%\PyHubInstaller
+  - 크로스 플랫폼 대응을 위해 OS별 경로 분기 로직 구현 필요

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,9 @@ BINARY_NAME=pyhub-installer
 MAIN_PATH=./cmd/pyhub-installer
 BUILD_DIR=./build
 VERSION?=dev
-LDFLAGS=-ldflags "-X main.version=${VERSION}"
+COMMIT?=$(shell git rev-parse --short HEAD 2>/dev/null || echo "none")
+DATE?=$(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS=-ldflags "-X main.version=${VERSION} -X main.commit=${COMMIT} -X main.date=${DATE}"
 
 # Default target
 .PHONY: all

--- a/internal/install/install.go
+++ b/internal/install/install.go
@@ -312,19 +312,42 @@ func getFallbackDirectories() []string {
 		return []string{"."}
 	}
 	
-	fallbacks := []string{
-		filepath.Join(homeDir, ".local", "bin"),
-		filepath.Join(homeDir, "bin"),
-	}
+	var fallbacks []string
 	
 	// Add platform-specific fallbacks
 	switch runtime.GOOS {
+	case "windows":
+		// Windows specific paths
+		if localAppData := os.Getenv("LOCALAPPDATA"); localAppData != "" {
+			fallbacks = append(fallbacks, filepath.Join(localAppData, "Programs"))
+		}
+		if programFiles := os.Getenv("ProgramFiles"); programFiles != "" {
+			fallbacks = append(fallbacks, filepath.Join(programFiles, "pyhub-installer"))
+		}
+		fallbacks = append(fallbacks, 
+			filepath.Join(homeDir, "bin"),
+			filepath.Join(homeDir, ".local", "bin"),
+		)
 	case "darwin":
 		// macOS specific paths
-		fallbacks = append(fallbacks, "/opt/homebrew/bin", "/usr/local/bin")
+		fallbacks = []string{
+			filepath.Join(homeDir, ".local", "bin"),
+			filepath.Join(homeDir, "bin"),
+			"/opt/homebrew/bin",
+			"/usr/local/bin",
+		}
 	case "linux":
 		// Linux specific paths
-		fallbacks = append(fallbacks, "/usr/local/bin")
+		fallbacks = []string{
+			filepath.Join(homeDir, ".local", "bin"),
+			filepath.Join(homeDir, "bin"),
+			"/usr/local/bin",
+		}
+	default:
+		fallbacks = []string{
+			filepath.Join(homeDir, ".local", "bin"),
+			filepath.Join(homeDir, "bin"),
+		}
 	}
 	
 	return fallbacks


### PR DESCRIPTION
## 개요
Windows 플랫폼 지원 개선과 버전 정보 확인 기능을 추가했습니다.

## 주요 변경사항

### 1. 플랫폼별 기본 설치 경로
- **Windows**: `%LOCALAPPDATA%\Programs` 또는 `%USERPROFILE%\bin`
- **macOS/Linux**: `/usr/local/bin`
- 더 이상 Windows에서 Unix 스타일 경로(`C:/usr/local/bin`) 사용하지 않음

### 2. version 명령 추가
```bash
$ pyhub-installer version
pyhub-installer v0.1.3
Commit: 3bea2bd
Built: 2025-06-07T01:59:11Z
Platform: windows/amd64
```

### 3. Windows PATH 우선순위 개선
```
1. %LOCALAPPDATA%\Programs
2. %ProgramFiles%\pyhub-installer
3. %USERPROFILE%\bin
4. %USERPROFILE%\.local\bin
```

### 4. 빌드 개선
- Makefile에서 자동으로 버전 정보 주입
- 커밋 해시와 빌드 시간 자동 포함

## 테스트
- [x] macOS에서 기본 경로 확인
- [x] version 명령 동작 확인
- [x] PATH 우선순위 테스트 통과

## 영향
- Windows 사용자 경험 크게 개선
- 버전 확인으로 디버깅 및 지원 용이

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Improve Windows support by using native install paths and fallback priority, add a version command for build metadata visibility, and automate version, commit, and date injection during build.

New Features:
- Add a 'version' command to display version, commit hash, build date, and platform
- Implement platform-specific default installation path detection

Enhancements:
- Improve Windows installation path priority and fallback directories
- Update install command to use the platform-specific default output directory

Build:
- Enhance Makefile to inject version, commit hash, and build date via ldflags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a version command to display version, commit, date, and platform information.
	- The installer now automatically selects a default installation path based on your operating system.
- **Bug Fixes**
	- Improved detection and handling of writable installation directories for better cross-platform support.
- **Documentation**
	- Updated notes to clarify recommended installation paths for Windows and the need for OS-specific path handling.
- **Refactor**
	- Enhanced logic for determining fallback installation directories to be more platform-aware.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->