### PR TITLE
fix: GitHub Actions 빌드 시 버전 정보 주입 누락 수정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,6 +38,12 @@ jobs:
           # Create build directory
           mkdir -p dist
           
+          # Get build information
+          VERSION="${{ github.ref_name }}"
+          COMMIT="${{ github.sha }}"
+          SHORT_COMMIT="${COMMIT:0:7}"
+          BUILD_DATE="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+          
           # Build matrix
           platforms=(
             "linux/amd64"
@@ -63,9 +69,9 @@ jobs:
             
             echo "Building for $GOOS/$GOARCH..."
             
-            # Build
+            # Build with version information
             CGO_ENABLED=0 GOOS=$GOOS GOARCH=$GOARCH \
-              go build -v -ldflags "-s -w" \
+              go build -v -ldflags "-s -w -X main.version=${VERSION} -X main.commit=${SHORT_COMMIT} -X main.date=${BUILD_DATE}" \
               -o "dist/${binary_name}" \
               ./cmd/pyhub-installer
             


### PR DESCRIPTION
## 개요
GitHub Actions로 빌드된 바이너리에서 `version` 명령 실행 시 버전이 "dev"로 표시되는 문제를 수정합니다.

## 변경사항
- 릴리스 워크플로우에 빌드 정보 변수 추가
  - `VERSION`: Git 태그 (예: v0.1.3)
  - `SHORT_COMMIT`: 짧은 커밋 해시 (7자리)
  - `BUILD_DATE`: ISO 형식 빌드 시간
- `go build` 명령의 ldflags에 버전 정보 주입

## 테스트
로컬에서 테스트 완료:
```bash
make build VERSION=v0.1.3
./build/pyhub-installer version
# 출력:
# pyhub-installer v0.1.3
# Commit: 77c4f49
# Built: 2025-06-07T02:26:36Z
# Platform: darwin/arm64
```

## 영향
- 모든 플랫폼 바이너리에서 올바른 버전 정보 표시
- 사용자가 설치한 버전을 정확히 확인 가능

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary by Sourcery

Inject version metadata into release binaries built via GitHub Actions to ensure accurate runtime version reporting

Bug Fixes:
- Fix missing version, commit hash, and build date in GitHub Actions-built binaries

CI:
- Extract VERSION, COMMIT, SHORT_COMMIT, and BUILD_DATE in the release workflow and embed them into the binary via go build ldflags

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Enhanced release workflow to embed version, commit, and build date information into compiled binaries for improved traceability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->